### PR TITLE
chore: output 'coverage' directory to './test'

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 dist
 node_modules
-coverage
+test/coverage
 webpack.config.*.js
 *Server.js
 gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 .DS_Store
 dist
 *.log
-coverage
+test/coverage
 gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ script:
   - npm run lint
   - npm test
   - npm run test:cov
-after_script: "cat coverage/lcov.info | codecov"
+after_script: "cat test/coverage/lcov.info | codecov"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test babel-node test/index.js | tap-spec",
-    "test:cov": "NODE_ENV=test babel-node $(npm bin)/isparta cover test/index.js",
+    "test:cov": "NODE_ENV=test babel-node $(npm bin)/isparta cover --dir ./test/coverage test/index.js",
     "start": "node devServer",
     "build:start": "NODE_ENV=production node prodServer",
     "build": "rimraf dist && NODE_ENV=production webpack --config webpack.config.prod.js --progress --profile --colors",


### PR DESCRIPTION
'coverage' directory should be put in the 'test' directory to reduce the number of directories at the first level.